### PR TITLE
fixing recreate_parent_column

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,4 +55,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/globals.R
+++ b/R/globals.R
@@ -52,8 +52,10 @@ globalVariables(unique(c(
   ".",
   # recreate_parent_column:
   "cols", "list_name", "name", "new_name", "sm_child", "sm_parent", "type", "value",
+  "new_in_old", "old_in_new",
   # review_cleaning:
   "cleaning_log_only", "df.new_value", "df.uuid", "question", "uniqe_row_id", "uuid",
+  "df.old_value", "logical_check",
   # review_cleaning_log:
   "cl_prob",
   # review_others:

--- a/tests/testthat/test-recreate_parent_column.R
+++ b/tests/testthat/test-recreate_parent_column.R
@@ -644,3 +644,41 @@ test_that("if the argument cleaning_log_to_append is present, the log will be ap
   expect_equal(actual_output$cleaning_log, expected_output)
 
 })
+
+test_that("the order of the choices in the parent columns does not change", {
+  actual_output <- recreate_parent_column(dataset = cleaningtools_clean_data,
+                                          uuid_column = "X_uuid",
+                                          kobo_survey = cleaningtools_survey,
+                                          kobo_choices = cleaningtools_choices,
+                                          sm_separator = ".")  %>%
+    suppressWarnings()
+
+  expected_outputs <- data.frame(
+    uuid = c("51324001-970c-4fb5-bacf-de696e1b7eaa",
+             "d5d26992-388b-4c71-a461-18a63cac8738",
+             "3b9732e2-a0d7-4dc3-962d-12efcd2ded15",
+             "728e4de0-7356-4bb5-9db4-9479b3ffe098"),
+    question = c("water_sources",
+                 "water_sources",
+                 "treat_drink_water_how",
+                 "treat_drink_water_how"),
+    change_type = c("change_response",
+                    "change_response",
+                    "blank_response",
+                    "blank_response"),
+    new_value = c("piped borehole",
+                  "piped borehole",
+                  NA_character_,
+                  NA_character_),
+    old_value = c("piped",
+                  "piped",
+                  "expose_sunlight",
+                  "filter"),
+    comment = c("Parent column changed to match children columns",
+                "Parent column changed to match children columns",
+                "changed to NA",
+                "changed to NA"))
+
+  expect_equal(actual_output[["correction_parent_sm_log"]], expected_outputs)
+})
+


### PR DESCRIPTION
The function would change the order of appearance of the parent columns and flag them as changes. In some surveys, options are the same but the order is different. The function would changed it  and later flags changes while it is this function that changed the order. I don't know why the order is different than the order of the columns,  possible options: the choices order changed, the fill in order

Also correcting the initial for loop condition as it was repeating for each options and not each select multiple type.