### PR TITLE
Change to clog xlsx output to allow drop down for re_code others. 

### DIFF
--- a/R/create_xlsx_cleaning_log.R
+++ b/R/create_xlsx_cleaning_log.R
@@ -113,6 +113,7 @@ create_formated_wb <- function(write_list,
 #' (default is FALSE)
 #' @param sm_dropdown_type Dropdown list options for select multiple questions:
 #' "numerical" (1/0) or "logical" (TRUE/FALSE). The default is logical.
+#' @param use_others Whether to include the parent values in recode_other clog issues (TRUE / FALSE). Defaults to FALSE. In order to work, other answer options must have the name 'other' in the choices sheet.
 #' @param kobo_survey Kobo survey dataframe
 #' @param kobo_choices Kobo choices dataframe
 #' @param output_path Output path. Default is NULL which will return a workbook instead of an excel file.
@@ -160,6 +161,7 @@ create_xlsx_cleaning_log <- function(write_list,
                                      body_front = "Arial Narrow",
                                      body_front_size = 11,
                                      use_dropdown = F,
+                                     use_others = F,
                                      sm_dropdown_type = NULL,
                                      kobo_survey = NULL,
                                      kobo_choices = NULL,
@@ -188,7 +190,9 @@ create_xlsx_cleaning_log <- function(write_list,
 
   tryCatch(
     if (!is.null(kobo_survey) & !is.null(kobo_choices) & use_dropdown == TRUE) {
-      data.val <- create_validation_list(kobo_choices, kobo_survey |> dplyr::filter(!stringr::str_detect(pattern = "(begin|end)(\\s+|_)group", type)))
+      data.val <- create_validation_list(kobo_choices,
+                                         kobo_survey |> dplyr::filter(!stringr::str_detect(pattern = "(begin|end)(\\s+|_)group", type)),
+                                         others = use_others)
     },
     error = function(e) {
       warning("Validation list was not created")

--- a/R/review_cleaning.R
+++ b/R/review_cleaning.R
@@ -66,8 +66,6 @@ create_cleaning_log <- function(raw_dataset,
     )
   }
 
-
-
   # check variable name [removed from clean data] ---------------------------
 
   if (check_for_variable_name == T) {
@@ -154,7 +152,6 @@ create_cleaning_log <- function(raw_dataset,
         check$comment <- "An alteration was performed"
         return(check)
       }
-      message(x)
     }, clean_dataset = clean_dataset, raw_dataset = raw_dataset) %>% do.call(rbind, .)
 
 
@@ -180,10 +177,10 @@ create_cleaning_log <- function(raw_dataset,
         check$comment <- "NA changed to value"
         return(check)
       }
-      message(x)
     }, clean_dataset = clean_dataset, raw_dataset = raw_dataset) %>% do.call(rbind, .)
 
   ############################# blank_response ############################################
+
   log[["blank_response"]] <-
     lapply(varlist, function(x, clean_dataset, raw_dataset) {
       check <-
@@ -203,7 +200,6 @@ create_cleaning_log <- function(raw_dataset,
         check$comment <- "changed to NA"
         return(check)
       }
-      message(x)
     }, clean_dataset = clean_dataset, raw_dataset = raw_dataset) %>% do.call(rbind, .)
 
   all_log <- do.call(dplyr::bind_rows, log)


### PR DESCRIPTION
**I have added some code to `create_xlsx_cleaning_log` so that dropdowns correctly appear for 'recode other' questions'.**

There is an additional function in utils `create_other_df ` which identifies other questions (assuming they are identifiable from having 'other' as a relevancy criteria) and calculates all of the acceptable answers from the parent other question. 

There is a small change to the helper function `create_validation_list` to then incorporate the output from `create_other_df`

There is an additional input parameter (T/F) to `create_xlsx_cleaning_log` to select whether to add the dropdown for others or not. 

See following file for reprex inputs and output:
[test_other_drop_down_output.xlsx](https://github.com/user-attachments/files/19960175/test_other_drop_down.xlsx)
[sample_test_data.csv](https://github.com/user-attachments/files/19960179/sample_test_data.csv)
[sample_test_clogs.csv](https://github.com/user-attachments/files/19960224/sample_test_clogs.csv)


reprex script:
```
library(readr)
library(readxl)
library(dplyr)

checked_dataset <- readr::read_csv(r"(C:\Users\alex.stephenson\Downloads/sample_test_data.csv)")
cleaning_log <- readr::read_csv(r"(C:\Users\alex.stephenson\Downloads/sample_test_clogs.csv)")

test_input <- list(checked_dataset = checked_dataset, cleaning_log = cleaning_log)

tool_path <- r"(C:\Users\alex.stephenson\Downloads/cleaningtools_test_SOM2406_IRF_baseline_TOOL.xlsx)"
kobo_survey <- read_excel(tool_path, sheet = "questions")
kobo_choices <- read_excel(tool_path, sheet = "choices")

tool <- read_excel(tool_path, sheet = "questions")
choices <- read_excel(tool_path, sheet = "choices")

test_input %>% create_xlsx_cleaning_log(.,
                                             cleaning_log_name = "cleaning_log",
                                             change_type_col = "change_type",
                                             column_for_color = "check_binding",
                                             header_front_size = 10,
                                             header_front_color = "#FFFFFF",
                                             header_fill_color = "#ee5859",
                                             header_front = "Calibri",
                                             body_front = "Calibri",
                                             body_front_size = 10,
                                             use_dropdown = T,
                                             use_others = T,
                                             sm_dropdown_type = "numerical",
                                             kobo_survey = kobo_survey,
                                             kobo_choices = kobo_choices,
                                             output_path = paste0("test_other_drop_down.xlsx"))
```

**Edit 2 - I have rewritten `recreate_parent_column` to make it much faster**

Hi data team, I have made another commit to this branch of cleaningtools. The previous way recreate_parent_column was written involved a lot of looping and joins, which are computationally quite inefficient. The new version uses pivot_longer + group_by + summarise with purrr list-columns, cutting runtime significantly on large datasets.

This is a useful addition for my workflows as in my daily cleaning pipeline I produce fully cleaned data - meaning recreate_parent_column gets run every day during data collection. I suppose for most other missions they are just doing this at the end, so might not be so pressing. When I `benchmarked` this, the new code is ~90% quicker. 

Most of the work is done when we are calculating `reconstructed_list`, which takes the original dataset, splits it out by select multiple, pivots out child question binaries then summarises the concatenated values based on the binaries equaling 1 / TRUE. In testing I have found that sometimes the old function will produce a row in the new clog even if the combination of child binaries is unchanged - this is because the old function implicitly reorders the concatenated values. The new function does not do this, and only makes a row in the clog if there is a different combination of binaries. This means sometimes the output of the clog looks different, but on inspection I have found the outputs of cleaned input / old output / new output all match up, just the order may be different. 
 
I also made a small change to create_cleaning_log -> the message(x) function call seems unnecessary if you're not debugging and it completely destroys your console history. 

***If you are not planning to update `cleaningtools` I would still appreciate any QA as I'd like to include this quicker process in my scripts.***